### PR TITLE
feat: add reusable Generate Changelog workflow and documentation

### DIFF
--- a/.github/workflow-templates/generate-changelog-generic-release-template.properties.json
+++ b/.github/workflow-templates/generate-changelog-generic-release-template.properties.json
@@ -1,0 +1,11 @@
+{
+  "name": "Generate Changelog (Generic Release)",
+  "description": "Reusable workflow for generating and optionally committing a changelog using conventional-changelog-cli.",
+  "iconName": "book",
+  "categories": ["release", "changelog", "automation"],
+  "filePatterns": [
+    "CHANGELOG.md"
+  ],
+  "documentation": "docs/generate-changelog-generic-release.md",
+  "workflowFile": "generate-changelog-generic-release-template.yml"
+}

--- a/.github/workflow-templates/generate-changelog-generic-release-template.yml
+++ b/.github/workflow-templates/generate-changelog-generic-release-template.yml
@@ -1,0 +1,59 @@
+name: Generate Changelog (Generic Release) (Template)
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        description: 'Node.js version for changelog tooling'
+        required: false
+        default: '20'
+        type: string
+      changelog_preset:
+        description: 'Conventional changelog preset'
+        required: false
+        default: 'angular'
+        type: string
+      changelog_file:
+        description: 'Path to changelog file'
+        required: false
+        default: 'CHANGELOG.md'
+        type: string
+      commit_changelog:
+        description: 'Automatically commit and push changelog updates'
+        required: false
+        default: true
+        type: boolean
+      tag_name:
+        description: 'Git tag name for release-specific changelog (optional)'
+        required: false
+        default: ''
+        type: string
+      release_count:
+        description: 'Number of releases to include in changelog (0 = all)'
+        required: false
+        default: 0
+        type: number
+      skip_ci:
+        description: 'Add [skip ci] to commit message'
+        required: false
+        default: true
+        type: boolean
+    outputs:
+      changelog_updated:
+        description: 'Whether changelog was updated'
+        value: ${{ jobs.generate-changelog.outputs.changelog_updated }}
+      changelog_path:
+        description: 'Path to the updated changelog file'
+        value: ${{ jobs.generate-changelog.outputs.changelog_path }}
+
+jobs:
+  generate-changelog:
+    uses: ./.github/workflows/generate-changelog-generic-release.yml
+    with:
+      node_version: ${{ inputs.node_version }}
+      changelog_preset: ${{ inputs.changelog_preset }}
+      changelog_file: ${{ inputs.changelog_file }}
+      commit_changelog: ${{ inputs.commit_changelog }}
+      tag_name: ${{ inputs.tag_name }}
+      release_count: ${{ inputs.release_count }}
+      skip_ci: ${{ inputs.skip_ci }}

--- a/.github/workflow-templates/generate-changelog-generic-release-template.yml
+++ b/.github/workflow-templates/generate-changelog-generic-release-template.yml
@@ -29,9 +29,9 @@ on:
         default: ''
         type: string
       release_count:
-        description: 'Number of releases to include in changelog (0 = all)'
+        description: 'Number of releases to include in changelog (-1 = all)'
         required: false
-        default: 0
+        default: -1
         type: number
       skip_ci:
         description: 'Add [skip ci] to commit message'

--- a/.github/workflows/generate-changelog-generic-release.yml
+++ b/.github/workflows/generate-changelog-generic-release.yml
@@ -111,21 +111,22 @@ jobs:
         run: |
           echo "Generating changelog with preset: ${{ inputs.changelog_preset }}"
 
-          # Build the conventional-changelog command
-          changelog_cmd="conventional-changelog -p ${{ inputs.changelog_preset }} -i ${{ inputs.changelog_file }} -s"
+
+          # Build up arguments for conventional-changelog
+          changelog_args=(-p "${{ inputs.changelog_preset }}" -i "${{ inputs.changelog_file }}" -s)
 
           # Add release count if specified
           if [[ "${{ inputs.release_count }}" != "0" ]]; then
-            changelog_cmd="$changelog_cmd -r ${{ inputs.release_count }}"
+            changelog_args+=(-r "${{ inputs.release_count }}")
           fi
 
           # Add tag name if specified
           if [[ -n "${{ inputs.tag_name }}" ]]; then
-            changelog_cmd="$changelog_cmd --tag-prefix '' --preset ${{ inputs.changelog_preset }} --tag ${{ inputs.tag_name }}"
+            changelog_args+=(--tag-prefix "" --preset "${{ inputs.changelog_preset }}" --tag "${{ inputs.tag_name }}")
           fi
 
-          echo "Running: $changelog_cmd"
-          eval $changelog_cmd
+          echo "Running: conventional-changelog ${changelog_args[@]}"
+          conventional-changelog "${changelog_args[@]}"
 
           # Check if changelog was actually updated
           if [[ -f "${{ inputs.changelog_file }}.backup" ]]; then

--- a/.github/workflows/generate-changelog-generic-release.yml
+++ b/.github/workflows/generate-changelog-generic-release.yml
@@ -121,7 +121,7 @@ jobs:
 
           # Add tag name if specified
           if [[ -n "${{ inputs.tag_name }}" ]]; then
-            changelog_cmd="$changelog_cmd --tag-prefix '' --preset ${{ inputs.changelog_preset }} --tag ${{ inputs.tag_name }}"
+            changelog_cmd="$changelog_cmd --tag-prefix '' --tag ${{ inputs.tag_name }}"
           fi
 
           echo "Running: $changelog_cmd"

--- a/.github/workflows/generate-changelog-generic-release.yml
+++ b/.github/workflows/generate-changelog-generic-release.yml
@@ -58,13 +58,6 @@ on:
         required: false
         default: true
         type: boolean
-    outputs:
-      changelog_updated:
-        description: 'Whether changelog was updated'
-        value: ${{ jobs.generate-changelog.outputs.changelog_updated }}
-      changelog_path:
-        description: 'Path to the updated changelog file'
-        value: ${{ jobs.generate-changelog.outputs.changelog_path }}
 
 
 permissions:

--- a/.github/workflows/generate-changelog-generic-release.yml
+++ b/.github/workflows/generate-changelog-generic-release.yml
@@ -49,9 +49,9 @@ on:
         default: ''
         type: string
       release_count:
-        description: 'Number of releases to include in changelog (0 = all)'
+        description: 'Number of releases to include in changelog (-1 = all)'
         required: false
-        default: 0
+        default: -1
         type: number
       skip_ci:
         description: 'Add [skip ci] to commit message'

--- a/.github/workflows/generate-changelog-generic-release.yml
+++ b/.github/workflows/generate-changelog-generic-release.yml
@@ -1,0 +1,230 @@
+# =============================================================================
+# Generate Changelog (Generic Release)
+# Reusable workflow for generating and optionally committing a changelog using
+# conventional-changelog-cli. Follows project boilerplate for clarity and reuse.
+# -----------------------------------------------------------------------------
+# Inputs:
+#   node_version (string, optional): Node.js version for changelog tooling (default: '20')
+#   changelog_preset (string, optional): Conventional changelog preset (default: 'angular')
+#   changelog_file (string, optional): Path to changelog file (default: 'CHANGELOG.md')
+#   commit_changelog (boolean, optional): Automatically commit and push changelog updates (default: true)
+#   tag_name (string, optional): Git tag name for release-specific changelog (default: '')
+#   release_count (number, optional): Number of releases to include in changelog (default: 0 = all)
+#   skip_ci (boolean, optional): Add [skip ci] to commit message (default: true)
+# Secrets:
+#   GITHUB_TOKEN: Used for repository authentication (provided by GitHub)
+# Outputs:
+#   changelog_updated: Whether changelog was updated
+#   changelog_path: Path to the updated changelog file
+# =============================================================================
+
+name: Generate Changelog (Generic Release)
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        description: 'Node.js version for changelog tooling'
+        required: false
+        default: '20'
+        type: string
+      changelog_preset:
+        description: 'Conventional changelog preset (angular, atom, codemirror, ember, eslint, express, jquery, jshint)'
+        required: false
+        default: 'angular'
+        type: string
+      changelog_file:
+        description: 'Path to changelog file'
+        required: false
+        default: 'CHANGELOG.md'
+        type: string
+      commit_changelog:
+        description: 'Automatically commit and push changelog updates'
+        required: false
+        default: true
+        type: boolean
+      tag_name:
+        description: 'Git tag name for release-specific changelog (optional)'
+        required: false
+        default: ''
+        type: string
+      release_count:
+        description: 'Number of releases to include in changelog (0 = all)'
+        required: false
+        default: 0
+        type: number
+      skip_ci:
+        description: 'Add [skip ci] to commit message'
+        required: false
+        default: true
+        type: boolean
+    outputs:
+      changelog_updated:
+        description: 'Whether changelog was updated'
+        value: ${{ jobs.generate-changelog.outputs.changelog_updated }}
+      changelog_path:
+        description: 'Path to the updated changelog file'
+        value: ${{ jobs.generate-changelog.outputs.changelog_path }}
+
+
+permissions:
+  contents: write
+
+jobs:
+  generate-changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    outputs:
+      changelog_updated: ${{ steps.generate.outputs.changelog_updated }}
+      changelog_path: ${{ inputs.changelog_file }}
+    steps:
+      # Checkout code
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Setup Node.js
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      # Install Conventional Changelog CLI
+      - name: Install Conventional Changelog CLI
+        run: npm install -g conventional-changelog-cli
+
+      # Backup Existing Changelog
+      - name: Backup Existing Changelog
+        run: |
+          if [[ -f "${{ inputs.changelog_file }}" ]]; then
+            cp "${{ inputs.changelog_file }}" "${{ inputs.changelog_file }}.backup"
+            echo "📄 Backed up existing changelog"
+          else
+            echo "📄 No existing changelog found, will create new one"
+          fi
+
+      # Generate Changelog
+      - name: Generate Changelog
+        id: generate
+        run: |
+          echo "Generating changelog with preset: ${{ inputs.changelog_preset }}"
+
+          # Build the conventional-changelog command
+          changelog_cmd="conventional-changelog -p ${{ inputs.changelog_preset }} -i ${{ inputs.changelog_file }} -s"
+
+          # Add release count if specified
+          if [[ "${{ inputs.release_count }}" != "0" ]]; then
+            changelog_cmd="$changelog_cmd -r ${{ inputs.release_count }}"
+          fi
+
+          # Add tag name if specified
+          if [[ -n "${{ inputs.tag_name }}" ]]; then
+            changelog_cmd="$changelog_cmd --tag-prefix '' --preset ${{ inputs.changelog_preset }} --tag ${{ inputs.tag_name }}"
+          fi
+
+          echo "Running: $changelog_cmd"
+          eval $changelog_cmd
+
+          # Check if changelog was actually updated
+          if [[ -f "${{ inputs.changelog_file }}.backup" ]]; then
+            if diff -q "${{ inputs.changelog_file }}" "${{ inputs.changelog_file }}.backup" > /dev/null; then
+              echo "changelog_updated=false" >> $GITHUB_OUTPUT
+              echo "📄 No changes detected in changelog"
+            else
+              echo "changelog_updated=true" >> $GITHUB_OUTPUT
+              echo "📄 Changelog updated with new content"
+            fi
+          else
+            echo "changelog_updated=true" >> $GITHUB_OUTPUT
+            echo "📄 New changelog created"
+          fi
+
+      # Validate Changelog Format
+      - name: Validate Changelog Format
+        if: steps.generate.outputs.changelog_updated == 'true'
+        run: |
+          echo "Validating changelog format..."
+          if [[ -f "${{ inputs.changelog_file }}" ]]; then
+            echo "✅ Changelog file exists"
+
+            # Check if file has content
+            if [[ -s "${{ inputs.changelog_file }}" ]]; then
+              echo "✅ Changelog has content"
+              echo "First 10 lines of changelog:"
+              head -10 "${{ inputs.changelog_file }}"
+            else
+              echo "❌ Changelog is empty"
+              exit 1
+            fi
+          else
+            echo "❌ Changelog file not found"
+            exit 1
+          fi
+
+      # Configure Git
+      - name: Configure Git
+        if: steps.generate.outputs.changelog_updated == 'true' && inputs.commit_changelog
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      # Commit and Push Changelog
+      - name: Commit and Push Changelog
+        if: steps.generate.outputs.changelog_updated == 'true' && inputs.commit_changelog
+        run: |
+          echo "Committing changelog updates..."
+          git add "${{ inputs.changelog_file }}"
+
+          # Build commit message
+          commit_msg="chore: update changelog"
+          if [[ -n "${{ inputs.tag_name }}" ]]; then
+            commit_msg="$commit_msg for ${{ inputs.tag_name }}"
+          fi
+          if [[ "${{ inputs.skip_ci }}" == "true" ]]; then
+            commit_msg="$commit_msg [skip ci]"
+          fi
+
+          if git diff --staged --quiet; then
+            echo "📄 No staged changes to commit"
+          else
+            git commit -m "$commit_msg"
+            git push origin ${{ github.ref_name }}
+            echo "✅ Changelog committed and pushed"
+          fi
+
+      # Upload Changelog Artifact
+      - name: Upload Changelog Artifact
+        if: steps.generate.outputs.changelog_updated == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-${{ github.run_id }}
+          path: ${{ inputs.changelog_file }}
+          retention-days: 30
+
+      # Cleanup Backup
+      - name: Cleanup Backup
+        if: always()
+        run: |
+          if [[ -f "${{ inputs.changelog_file }}.backup" ]]; then
+            rm "${{ inputs.changelog_file }}.backup"
+            echo "🧹 Cleaned up backup file"
+          fi
+
+      # Changelog Generation Summary
+      - name: Changelog Generation Summary
+        if: always()
+        run: |
+          echo "## 📝 Changelog Generation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Updated**: ${{ steps.generate.outputs.changelog_updated == 'true' && '✅ Yes' || '📄 No changes' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Preset**: ${{ inputs.changelog_preset }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **File**: ${{ inputs.changelog_file }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Auto Commit**: ${{ inputs.commit_changelog }}" >> $GITHUB_STEP_SUMMARY
+          if [[ -n "${{ inputs.tag_name }}" ]]; then
+            echo "- **Tag**: ${{ inputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [[ "${{ inputs.release_count }}" != "0" ]]; then
+            echo "- **Release Count**: ${{ inputs.release_count }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "- **Node.js Version**: ${{ inputs.node_version }}" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial repository setup with reusable GitHub Actions workflows
+- Generate Changelog (Generic Release) reusable workflow ([docs](docs/generate-changelog-generic-release.md))
 - Build workflows for .NET solutions and packages
 - Test workflows for .NET unit tests with coverage
 - Publishing workflows for NuGet packages and GitHub releases

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A comprehensive collection of reusable GitHub Actions workflows designed to stre
 | **Build Package** | NuGet package creation | PR, Push | [📖 Docs](docs/build-package-dotnet-ci.md) |
 | **Publish Package** | NuGet package publishing | Release | [📖 Docs](docs/publish-package-dotnet-release.md) |
 | **Git Tagging** | Automated release tagging | Release | [📖 Docs](docs/tag-git-generic-release.md) |
+| **Generate Changelog** | Automated changelog generation & commit | Release, Manual | [📖 Docs](docs/generate-changelog-generic-release.md) |
 
 ## 🔧 Workflow Dependencies
 
@@ -78,6 +79,8 @@ graph TD
   - `GITHUB_TOKEN` (automatically provided)
 
 ## 📚 Documentation
+
+- [Generate Changelog (Generic Release)](docs/generate-changelog-generic-release.md)
 
 Detailed documentation is available for each workflow:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,12 +48,10 @@ This repository provides a set of reusable GitHub Actions workflows for .NET and
 
 ### 6. tag-git-generic-release.yml
 
-- **Purpose:** Creates and pushes a git tag using any provided string (universal, not limited to semantic versioning).
-- **Inputs:** `version`, `tag_prefix`, `tag_annotation`, `tag_branches`
-- **Docs:** No dedicated doc file; see workflow header for details.
 
----
+### 7. generate-changelog-generic-release.yml
 
+- **Purpose:** Generates and optionally commits a changelog using conventional-changelog-cli. Supports custom presets, file paths, release counts, and tagging.
 ## Usage
 
 - Each workflow is designed for reusability via `workflow_call` and can be referenced from other workflows in your repository or organization.

--- a/docs/generate-changelog-generic-release.md
+++ b/docs/generate-changelog-generic-release.md
@@ -30,7 +30,7 @@ It can be used as a reusable workflow via `workflow_call` in other repositories.
 | `changelog_file`   | string  | `CHANGELOG.md`  | Path to changelog file                                                      |
 | `commit_changelog` | boolean | `true`          | Automatically commit and push changelog updates                             |
 | `tag_name`         | string  | `""`            | Git tag name for release-specific changelog (optional)                      |
-| `release_count`    | number  | `0`             | Number of releases to include in changelog (`0` = all)                      |
+| `release_count`    | number  | `-1`            | Number of releases to include in changelog (`-1` = all)                     |
 | `skip_ci`          | boolean | `true`          | Add `[skip ci]` to commit message                                           |
 
 ---
@@ -60,7 +60,7 @@ jobs:
       changelog_file: 'CHANGELOG.md'
       commit_changelog: true
       tag_name: ''
-      release_count: 0
+      release_count: -1
       skip_ci: true
 ```
 

--- a/docs/generate-changelog-generic-release.md
+++ b/docs/generate-changelog-generic-release.md
@@ -1,0 +1,90 @@
+# Generate Changelog (Generic Release) Workflow
+
+> **Reusable workflow for generating and optionally committing a changelog using [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog).**
+
+---
+
+## Overview
+
+This workflow automates changelog generation for your repository using a configurable preset and options.  
+It can be used as a reusable workflow via `workflow_call` in other repositories.
+
+---
+
+## Features
+
+- Generates a changelog file based on commit history and a conventional changelog preset.
+- Optionally commits and pushes changelog updates.
+- Supports custom changelog file paths, release counts, and tag-specific changelogs.
+- Uploads the changelog as a workflow artifact.
+- Provides a summary in the workflow run.
+
+---
+
+## Inputs
+
+| Name               | Type    | Default         | Description                                                                 |
+|--------------------|---------|-----------------|-----------------------------------------------------------------------------|
+| `node_version`     | string  | `20`            | Node.js version for changelog tooling                                       |
+| `changelog_preset` | string  | `angular`       | Conventional changelog preset (angular, atom, etc.)                         |
+| `changelog_file`   | string  | `CHANGELOG.md`  | Path to changelog file                                                      |
+| `commit_changelog` | boolean | `true`          | Automatically commit and push changelog updates                             |
+| `tag_name`         | string  | `""`            | Git tag name for release-specific changelog (optional)                      |
+| `release_count`    | number  | `0`             | Number of releases to include in changelog (`0` = all)                      |
+| `skip_ci`          | boolean | `true`          | Add `[skip ci]` to commit message                                           |
+
+---
+
+## Outputs
+
+| Name               | Description                                 |
+|--------------------|---------------------------------------------|
+| `changelog_updated`| Whether changelog was updated (`true/false`)|
+| `changelog_path`   | Path to the updated changelog file          |
+
+---
+
+## Usage Example
+
+```yaml
+name: Generate Changelog
+
+on:
+  workflow_dispatch:
+
+jobs:
+  changelog:
+    uses: your-org/github-actions/.github/workflows/generate-changelog-generic-release.yml@main
+    with:
+      changelog_preset: 'angular'
+      changelog_file: 'CHANGELOG.md'
+      commit_changelog: true
+      tag_name: ''
+      release_count: 0
+      skip_ci: true
+```
+
+---
+
+## Best Practices
+
+- Use this workflow after merging PRs or before releases to keep your changelog up to date.
+- Adjust `changelog_preset` to match your commit style.
+- Set `commit_changelog: false` if you want to review changes before committing.
+- Use `tag_name` for generating changelogs for specific releases.
+
+---
+
+## Related Workflows
+
+- [Tag Git (Generic Release)](tag-git-generic-release.md)
+- [Build Package (.NET CI)](build-package-dotnet-ci.md)
+
+---
+
+## References
+
+- [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog)
+- [GitHub Actions: Reusable Workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+
+---


### PR DESCRIPTION
# Pull Request

## Description
This PR adds a reusable workflow for generating and optionally committing a changelog using `conventional-changelog-cli`, following the project’s workflow boilerplate and documentation standards.  
It includes:
- `.github/workflows/generate-changelog-generic-release.yml` (main workflow)
- `.github/workflow-templates/generate-changelog-generic-release-template.yml` (template)
- `.github/workflow-templates/generate-changelog-generic-release-template.properties.json`
- `docs/generate-changelog-generic-release.md` (documentation)
- Updates to `README.md`, `docs/README.md`, and `CHANGELOG.md`

Fixes # (issue)

## Type of change

- [x] New feature
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (workflow tested via template)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context
This workflow enables automated changelog management for any repository using this action as a reusable workflow.  
Documentation and templates are provided for easy