### PR TITLE
feat: update GitVersion command to use dotnet-gitversion for semantic…

### DIFF
--- a/.github/workflows/version-semver-generic-ci.yml
+++ b/.github/workflows/version-semver-generic-ci.yml
@@ -77,9 +77,9 @@ jobs:
         id: gitversion
         run: |
           if [ "${{ inputs.gitversion_config }}" != "" ]; then
-            gitversion /output json -c "${{ inputs.gitversion_config }}" | tee version.json
+            dotnet-gitversion /output json -c "${{ inputs.gitversion_config }}" | tee version.json
           else
-            gitversion /output json | tee version.json
+            dotnet-gitversion /output json | tee version.json
           fi
           echo "semver=$(cat version.json | jq -r ".SemVer")" >> $GITHUB_OUTPUT
           echo "major=$(cat version.json | jq -r ".Major")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow `.github/workflows/version-semver-generic-ci.yml` to use `dotnet-gitversion` instead of `gitversion` for semantic versioning.  
This fixes the issue where the workflow failed with "gitversion: command not found" when GitVersion is installed as a .NET tool.

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (workflow comments)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

This change ensures compatibility with the way GitVersion is installed by the setup